### PR TITLE
Add Ollama streaming support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.2.0]
+
+### Added
+- Added support for Ollama `api/chat` endpoint streaming responses.
+
 ## [0.1.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0]
 
 ### Added
-- Added support for Ollama `api/chat` endpoint streaming responses.
+- Added support for Ollama `api/chat` endpoint streaming responses (`flavor = OllamaStream()`).
 
 ## [0.1.0]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StreamCallbacks"
 uuid = "c1b9e933-98a0-46fc-8ea7-3b58b195fb0a"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/StreamCallbacks.jl
+++ b/src/StreamCallbacks.jl
@@ -11,4 +11,6 @@ include("stream_openai.jl")
 
 include("stream_anthropic.jl")
 
+include("stream_ollama.jl")
+
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -70,6 +70,7 @@ Available flavors:
 abstract type AbstractStreamFlavor end
 struct OpenAIStream <: AbstractStreamFlavor end
 struct AnthropicStream <: AbstractStreamFlavor end
+struct OllamaStream <: AbstractStreamFlavor end
 
 ## Default implementations
 """

--- a/src/stream_ollama.jl
+++ b/src/stream_ollama.jl
@@ -1,0 +1,47 @@
+# Custom methods for Ollama streaming -- flavor=OllamaStream()
+# works only for Ollama `api/chat` endpoint!!
+
+"Terminates the stream when the `done` key in the JSON object is `true`."
+function is_done(flavor::OllamaStream, chunk::StreamChunk; kwargs...)
+    !isnothing(chunk.json) && haskey(chunk.json, "done") && chunk.json["done"] == true
+end
+function extract_content(flavor::OllamaStream, chunk::StreamChunk; kwargs...)
+    isnothing(chunk.json) && return nothing
+    message = get(chunk.json, :message, Dict())
+    out = get(message, :content, nothing)
+end
+function build_response_body(
+        flavor::OllamaStream, cb::AbstractStreamCallback; verbose::Bool = false, kwargs...)
+    isempty(cb.chunks) && return nothing
+    response = nothing
+    usage = nothing
+    content = IOBuffer()
+    for i in eachindex(cb.chunks)
+        chunk = cb.chunks[i]
+        ## validate that we can access choices
+        isnothing(chunk.json) && continue
+        !haskey(chunk.json, :message) && continue
+        if isnothing(response)
+            ## do it only once the first time when we have the json
+            response = chunk.json |> copy
+        end
+        if isnothing(usage) && ((haskey(chunk.json, :prompt_eval_count) ||
+             haskey(chunk.json, :eval_count)))
+            fields = [
+                :prompt_eval_count, :prompt_eval_duration, :eval_duration, :eval_count]
+            usage = Dict(field => chunk.json[field]
+            for field in fields if haskey(chunk.json, field))
+        end
+        message = chunk.json[:message]
+        temp = get(message, :content, nothing)
+        if !isnothing(temp)
+            write(content, temp)
+        end
+    end
+    ## We know we have at least one chunk, let's use it for final response
+    if !isnothing(response) && haskey(response, :message)
+        response[:message][:content] = String(take!(content))
+        !isnothing(usage) && merge!(response, usage)
+    end
+    return response
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using HTTP, JSON3
 using StreamCallbacks: build_response_body, is_done, extract_chunks, print_content,
                        callback, handle_error_message, extract_content
 using StreamCallbacks: AbstractStreamFlavor, OpenAIStream, AnthropicStream, StreamChunk,
-                       StreamCallback
+                       StreamCallback, OllamaStream
 
 @testset "StreamCallbacks.jl" begin
     @testset "Code quality (Aqua.jl)" begin
@@ -15,4 +15,5 @@ using StreamCallbacks: AbstractStreamFlavor, OpenAIStream, AnthropicStream, Stre
     include("shared_methods.jl")
     include("stream_openai.jl")
     include("stream_anthropic.jl")
+    include("stream_ollama.jl")
 end

--- a/test/stream_ollama.jl
+++ b/test/stream_ollama.jl
@@ -1,0 +1,121 @@
+@testset "is_done" begin
+    # Test case 1: JSON with done = true
+    done_chunk = StreamChunk(
+        nothing,
+        """{"done":true}""",
+        JSON3.read("""{"done":true}""")
+    )
+    @test is_done(OllamaStream(), done_chunk) == true
+
+    # Test case 2: JSON with done = false
+    not_done_chunk = StreamChunk(
+        nothing,
+        """{"done":false}""",
+        JSON3.read("""{"done":false}""")
+    )
+    @test is_done(OllamaStream(), not_done_chunk) == false
+
+    # Test case 3: JSON without done key
+    no_done_chunk = StreamChunk(
+        nothing,
+        """{"message":{"content":"Hello"}}""",
+        JSON3.read("""{"message":{"content":"Hello"}}""")
+    )
+    @test is_done(OllamaStream(), no_done_chunk) == false
+
+    # Test case 4: Non-JSON chunk
+    non_json_chunk = StreamChunk(
+        nothing,
+        "This is not JSON",
+        nothing
+    )
+    @test is_done(OllamaStream(), non_json_chunk) == false
+end
+
+@testset "extract_content" begin
+    # Test case 1: Valid JSON with content
+    valid_chunk = StreamChunk(
+        nothing,
+        """{"message":{"content":"Hello from Ollama"}}""",
+        JSON3.read("""{"message":{"content":"Hello from Ollama"}}""")
+    )
+    @test extract_content(OllamaStream(), valid_chunk) == "Hello from Ollama"
+
+    # Test case 2: JSON without message key
+    no_message_chunk = StreamChunk(
+        nothing,
+        """{"other":"data"}""",
+        JSON3.read("""{"other":"data"}""")
+    )
+    @test isnothing(extract_content(OllamaStream(), no_message_chunk))
+
+    # Test case 3: JSON with empty content
+    empty_content_chunk = StreamChunk(
+        nothing,
+        """{"message":{"content":""}}""",
+        JSON3.read("""{"message":{"content":""}}""")
+    )
+    @test extract_content(OllamaStream(), empty_content_chunk) == ""
+
+    # Test case 4: Non-JSON chunk
+    non_json_chunk = StreamChunk(
+        nothing,
+        "This is not JSON",
+        nothing
+    )
+    @test isnothing(extract_content(OllamaStream(), non_json_chunk))
+end
+
+@testset "build_response_body" begin
+    # Test case 1: Empty chunks
+    cb_empty = StreamCallback(flavor = OllamaStream())
+    @test isnothing(build_response_body(OllamaStream(), cb_empty))
+
+    # Test case 2: Single complete chunk
+    cb_single = StreamCallback(flavor = OllamaStream())
+    push!(cb_single.chunks,
+        StreamChunk(
+            nothing,
+            """{"model":"ollama","created_at":"2023-11-06T12:34:56Z","message":{"role":"assistant","content":"Hello"},"done":true}""",
+            JSON3.read("""{"model":"ollama","created_at":"2023-11-06T12:34:56Z","message":{"role":"assistant","content":"Hello"},"done":true}""")
+        ))
+    response = build_response_body(OllamaStream(), cb_single)
+    @test response[:model] == "ollama"
+    @test response[:message][:content] == "Hello"
+
+    # Test case 3: Multiple chunks forming a complete response
+    cb_multiple = StreamCallback(flavor = OllamaStream())
+    push!(cb_multiple.chunks,
+        StreamChunk(
+            nothing,
+            """{"model":"ollama","created_at":"2023-11-06T12:34:56Z","message":{"role":"assistant","content":"Hello"},"done":false}""",
+            JSON3.read("""{"model":"ollama","created_at":"2023-11-06T12:34:56Z","message":{"role":"assistant","content":"Hello"},"done":false}""")
+        ))
+    push!(cb_multiple.chunks,
+        StreamChunk(
+            nothing,
+            """{"model":"ollama","created_at":"2023-11-06T12:34:57Z","message":{"role":"assistant","content":" world"},"done":false}""",
+            JSON3.read("""{"model":"ollama","created_at":"2023-11-06T12:34:57Z","message":{"role":"assistant","content":" world"},"done":false}""")
+        ))
+    push!(cb_multiple.chunks,
+        StreamChunk(
+            nothing,
+            """{"model":"ollama","created_at":"2023-11-06T12:34:58Z","message":{"role":"assistant","content":"!"},"done":true}""",
+            JSON3.read("""{"model":"ollama","created_at":"2023-11-06T12:34:58Z","message":{"role":"assistant","content":"!"},"done":true}""")
+        ))
+    response = build_response_body(OllamaStream(), cb_multiple)
+    @test response[:model] == "ollama"
+    @test response[:message][:content] == "Hello world!"
+
+    # Test case 4: Chunks with usage information
+    cb_usage = StreamCallback(flavor = OllamaStream())
+    push!(cb_usage.chunks,
+        StreamChunk(
+            nothing,
+            """{"model":"ollama","created_at":"2023-11-06T12:34:56Z","message":{"role":"assistant","content":"Test"},"done":true,"prompt_eval_count":10,"eval_count":5}""",
+            JSON3.read("""{"model":"ollama","created_at":"2023-11-06T12:34:56Z","message":{"role":"assistant","content":"Test"},"done":true,"prompt_eval_count":10,"eval_count":5}""")
+        ))
+    response = build_response_body(OllamaStream(), cb_usage)
+    @test response[:prompt_eval_count] == 10
+    @test response[:eval_count] == 5
+end


### PR DESCRIPTION
- Added support for Ollama `api/chat` endpoint streaming responses (`flavor = OllamaStream()`).