### PR TITLE
Improved ndjson support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.4.0]
+
+### Added
+- Export the flavor `OllamaStream` for Ollama streaming responses.
+
+### Fixed
+- Fixes assertion for content-type in `OllamaStream` response (`application/x-ndjson`, not `text/event-stream`).
+
 ## [0.3.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StreamCallbacks"
 uuid = "c1b9e933-98a0-46fc-8ea7-3b58b195fb0a"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/StreamCallbacks.jl
+++ b/src/StreamCallbacks.jl
@@ -3,7 +3,8 @@ module StreamCallbacks
 using HTTP, JSON3
 using PrecompileTools
 
-export StreamCallback, StreamChunk, OpenAIStream, AnthropicStream, streamed_request!
+export StreamCallback, StreamChunk, OpenAIStream, AnthropicStream, OllamaStream,
+       streamed_request!
 include("interface.jl")
 
 include("shared_methods.jl")

--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -1,6 +1,8 @@
 # Simulate some data
 blob = "event: start\ndata: {\"key\": \"value\"}\n\nevent: end\ndata: {\"status\": \"complete\"}\n\n"
 chunks, spillover = extract_chunks(OpenAIStream(), blob)
+blob = "{\"key\":\"value\", \"done\":true}"
+chunks, spillover = extract_chunks(OllamaStream(), blob)
 
 # Chunk examples
 io = IOBuffer()

--- a/src/shared_methods.jl
+++ b/src/shared_methods.jl
@@ -13,6 +13,7 @@ Returns a list of `StreamChunk` and the next spillover (if message was incomplet
         spillover::AbstractString = "", verbose::Bool = false, kwargs...)
     chunks = StreamChunk[]
     next_spillover = ""
+    ## TODO: Implement first-class support of newline delimited JSON // application/x-ndjson
     ## SSE come separated by double-newlines
     blob_split = split(blob, "\n\n")
     for (bi, chunk) in enumerate(blob_split)
@@ -204,7 +205,12 @@ function streamed_request!(cb::AbstractStreamCallback, url, headers, input; kwar
                         for header in response.headers
                         if lowercase(header[1]) == "content-type"]
         @assert length(content_type)==1 "Content-Type header must be present and unique"
-        @assert occursin("text/event-stream", content_type[1]) "Content-Type header include the type text/event-stream"
+        ## Provide barebone support for application/x-ndjson (Ollama) -- it will emit "buffer spillover warnings
+        @assert occursin(
+            "application/x-ndjson", content_type[1])||!(cb.flavor isa OllamaStream) "For OllamaStream flavor, Content-Type must be application/x-ndjson"
+        ## For non-ollama streams, we accept text/event-stream
+        @assert !(cb.flavor isa
+                  OllamaStream)&&occursin("text/event-stream", content_type[1]) "Content-Type header include the type text/event-stream"
 
         isdone = false
         ## messages might be incomplete, so we need to keep track of the spillover

--- a/src/stream_ollama.jl
+++ b/src/stream_ollama.jl
@@ -1,6 +1,33 @@
 # Custom methods for Ollama streaming -- flavor=OllamaStream()
 # works only for Ollama `api/chat` endpoint!!
 
+@inline function extract_chunks(flavor::OllamaStream, blob::AbstractString;
+        spillover::AbstractString = "", verbose::Bool = false, kwargs...)
+    @assert spillover=="" "OllamaStream does not support spillover"
+    chunks = StreamChunk[]
+    ## Assumes application/x-ndjson format, not SSE!
+    blob_split = split(blob, "\n\n")
+    for (bi, chunk) in enumerate(blob_split)
+        isempty(chunk) && continue
+        event_name = nothing
+        data = chunk
+        ## try to build a JSON object if it's a well-formed JSON string
+        json = if startswith(data, '{') && endswith(data, '}')
+            try
+                JSON3.read(data)
+            catch e
+                verbose && @warn "Cannot parse JSON: $data"
+                nothing
+            end
+        else
+            nothing
+        end
+        ## Create a new chunk
+        push!(chunks, StreamChunk(event_name, data, json))
+    end
+    return chunks, spillover
+end
+
 "Terminates the stream when the `done` key in the JSON object is `true`."
 function is_done(flavor::OllamaStream, chunk::StreamChunk; kwargs...)
     !isnothing(chunk.json) && haskey(chunk.json, "done") && chunk.json["done"] == true

--- a/src/stream_ollama.jl
+++ b/src/stream_ollama.jl
@@ -10,7 +10,7 @@
     for (bi, chunk) in enumerate(blob_split)
         isempty(chunk) && continue
         event_name = nothing
-        data = chunk
+        data = rstrip(chunk, '\n')
         ## try to build a JSON object if it's a well-formed JSON string
         json = if startswith(data, '{') && endswith(data, '}')
             try


### PR DESCRIPTION
### Added
- Export the flavor `OllamaStream` for Ollama streaming responses.

### Fixed
- Fixes assertion for content-type in `OllamaStream` response (`application/x-ndjson`, not `text/event-stream`).
