### PR TITLE
Add Anthropic `message_delta` fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/
+
+# macOS
+.DS_Store
+# VSCode
+.vscode/
+# Scratch files
+_*.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.5.2]
+
+### Fixed
+- Fix for Anthropic streaming responses where the `message_start` event is not sent and stream starts with `message_delta` event (we must handle that response is `nothing`).
+
 ## [0.5.1]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StreamCallbacks"
 uuid = "c1b9e933-98a0-46fc-8ea7-3b58b195fb0a"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/stream_anthropic.jl
+++ b/src/stream_anthropic.jl
@@ -56,8 +56,10 @@ function build_response_body(
         end
         ## Update stop reason and usage
         if chunk.event == :message_delta
-            response = merge(response, get(chunk.json, :delta, Dict()))
-            usage = merge(usage, get(chunk.json, :usage, Dict()))
+            response = isnothing(response) ? get(chunk.json, :delta, Dict()) :
+                       merge(response, get(chunk.json, :delta, Dict()))
+            usage = isnothing(usage) ? get(chunk.json, :usage, Dict()) :
+                    merge(usage, get(chunk.json, :usage, Dict()))
         end
 
         ## Load text chunks


### PR DESCRIPTION
- Fix for Anthropic streaming responses where the `message_start` event is not sent and stream starts with `message_delta` event (we must handle that response is `nothing`).

Fixes https://github.com/svilupp/StreamCallbacks.jl/issues/10