### PR TITLE
Fix: Support Anthropic text_delta format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0]
 
 ### Added
-- Support for Anthropic's text_delta format in content extraction in case thinking is enabled (set like this `cb = StreamCallback(; out = stdout, flavor = AnthropicStream(), kwargs = (; include_thinking = false))` to see it). We now let all index chunks pass through.
+- Support for Anthropic's text_delta format in content extraction in case thinking is enabled (disable it like this `cb = StreamCallback(; out = stdout, flavor = AnthropicStream(), kwargs = (; include_thinking = false))`). We now let all index chunks pass through.
 
 ### Fixed
 - Fixed assertion for content-type to be more informative when you hit limits or some model error (see the status code and response headers).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [0.5.3]
+## [0.6.0]
+
+### Added
+- Support for Anthropic's text_delta format in content extraction in case thinking is enabled (set like this `cb = StreamCallback(; out = stdout, flavor = AnthropicStream(), kwargs = (; include_thinking = false))` to see it). We now let all index chunks pass through.
 
 ### Fixed
-- Support for Anthropic's text_delta format in content extraction in case thinking is enabled
+- Fixed assertion for content-type to be more informative when you hit limits or some model error (see the status code and response headers).
 
 ## [0.5.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.5.3]
+
+### Fixed
+- Support for Anthropic's text_delta format in content extraction in case thinking is enabled
+
 ## [0.5.2]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StreamCallbacks"
 uuid = "c1b9e933-98a0-46fc-8ea7-3b58b195fb0a"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.5.3"
+version = "0.6.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StreamCallbacks"
 uuid = "c1b9e933-98a0-46fc-8ea7-3b58b195fb0a"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ StreamCallbacks.jl is designed to unify streaming interfaces for Large Language 
 
 ## Installation
 
-You can install StreamCallbacks.jl via the package manager (it's not registered yet):
+You can install StreamCallbacks.jl via the package manager:
 
 ```julia
 import Pkg
-Pkg.add(path="https://github.com/svilupp/StreamCallbacks.jl")
+Pkg.add("StreamCallbacks")
 ```
 
 ## Getting Started

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,11 +20,11 @@ StreamCallbacks.jl is designed to unify streaming interfaces for Large Language 
 
 ## Installation
 
-You can install StreamCallbacks.jl via the package manager (it's not registered yet):
+You can install StreamCallbacks.jl via the package manager:
 
 ```julia
 import Pkg
-Pkg.add(path="https://github.com/svilupp/StreamCallbacks.jl")
+Pkg.add("StreamCallbacks")
 ```
 
 ## Getting Started

--- a/examples/anthropic_example.jl
+++ b/examples/anthropic_example.jl
@@ -1,0 +1,42 @@
+# Calling Anthropic with StreamCallbacks
+using HTTP, JSON3
+using StreamCallbacks
+
+## Prepare target and auth
+url = "https://api.anthropic.com/v1/messages"
+headers = [
+    "anthropic-version" => "2023-06-01",
+    "x-api-key" => "$(get(ENV, "ANTHROPIC_API_KEY", ""))"
+];
+
+## Send the request
+cb = StreamCallback(; out = stdout, flavor = AnthropicStream())
+messages = [Dict("role" => "user",
+    "content" => "Count from 1 to 10. Start with numbers only.")]
+payload = IOBuffer()
+JSON3.write(payload,
+    (; stream = true, messages, model = "claude-3-5-haiku-latest", max_tokens = 2048))
+## , stop_sequences = ["2"]
+resp = streamed_request!(cb, url, headers, payload);
+
+## Check the response
+resp # should be a `HTTP.Response` object with a message body like if we wouldn't use streaming
+
+## Check the callback
+cb.chunks # should be a vector of `StreamChunk` objects, each with a `json` field with received data from the API
+
+# TIP: For debugging, use `cb.verbose = true` in the `StreamCallback` constructor to get more details on each chunk and enable DEBUG loglevel.
+
+# This is the response body we get from the API but built together as if we didn't use streaming
+StreamCallbacks.build_response_body(AnthropicStream(), cb)
+
+# Show the thinking stream
+cb = StreamCallback(;
+    out = stdout, flavor = AnthropicStream(), kwargs = (; include_thinking = false))
+messages = [Dict("role" => "user",
+    "content" => "Count from 1 to 10000, skip prime numbers. Start with numbers only.")]
+payload = IOBuffer()
+JSON3.write(payload,
+    (; stream = true, messages, model = "claude-3-7-haiku-20250219",
+        max_tokens = 2500, thinking = Dict(:type => "enabled", :budget_tokens => 2000)))
+resp = streamed_request!(cb, url, headers, payload);

--- a/src/shared_methods.jl
+++ b/src/shared_methods.jl
@@ -209,9 +209,16 @@ function streamed_request!(cb::AbstractStreamCallback, url, headers, input; kwar
             @assert occursin(
                 "application/x-ndjson", lowercase(content_type[1])) "For OllamaStream flavor, Content-Type must be application/x-ndjson"
         else
-            ## For non-ollama streams, we accept text/event-stream
+            ## For non-ollama streams, we accept only text/event-stream
             @assert occursin(
-                "text/event-stream", lowercase(content_type[1])) "Content-Type header include the type text/event-stream"
+                "text/event-stream", lowercase(content_type[1])) """
+                Content-Type header should include the type text/event-stream.
+                Received type: $(content_type[1])
+                Status code: $(response.status)
+                Response headers:\n - $(join(["$k: $v" for (k,v) in response.headers], "\n - "))
+                Response body: $(String(response.body))
+                Please check the model you are using and that you set `stream=true`.
+                """
         end
 
         isdone = false

--- a/src/stream_anthropic.jl
+++ b/src/stream_anthropic.jl
@@ -6,12 +6,12 @@ end
 
 """
     extract_content(flavor::AnthropicStream, chunk::AbstractStreamChunk;
-        include_thinking::Bool = false, kwargs...)
+        include_thinking::Bool = true, kwargs...)
 
 Extract the content from the chunk.
 """
 function extract_content(flavor::AnthropicStream, chunk::AbstractStreamChunk;
-        include_thinking::Bool = false, kwargs...)
+        include_thinking::Bool = true, kwargs...)
     isnothing(chunk.json) && return nothing
 
     # Track message state

--- a/test/stream_anthropic.jl
+++ b/test/stream_anthropic.jl
@@ -109,55 +109,136 @@ end
     chunk_nil = StreamChunk(:content_block_delta, "{}", nothing)
     @test isnothing(extract_content(AnthropicStream(), chunk_nil))
 
-    # Test case 2: Non-content_block_delta chunk type should return nothing
-    chunk_wrong_type = StreamChunk(
+    # Test case 2: message_start event should return nothing
+    chunk_message_start = StreamChunk(
+        :message_start,
+        """{"type":"message_start","message":{"id":"msg_01...","role":"assistant","content":[]}}""",
+        JSON3.read("""{"type":"message_start","message":{"id":"msg_01...","role":"assistant","content":[]}}""")
+    )
+    @test isnothing(extract_content(AnthropicStream(), chunk_message_start))
+
+    # Test case 3: content_block_start with text should return the text
+    chunk_block_start = StreamChunk(
         :content_block_start,
-        """{"type":"content_block_start","content_block":{"type":"text","text":"Hello"}}""",
-        JSON3.read("""{"type":"content_block_start","content_block":{"type":"text","text":"Hello"}}""")
+        """{"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hi!"}}""",
+        JSON3.read("""{"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Hi!"}}""")
     )
-    @test isnothing(extract_content(AnthropicStream(), chunk_wrong_type))
+    @test extract_content(AnthropicStream(), chunk_block_start) == "Hi!"
 
-    # Test case 3: Basic text_delta extraction
-    chunk_text = StreamChunk(
+    # Test case 4: content_block_stop without content_block should return nothing
+    chunk_block_stop = StreamChunk(
+        :content_block_stop,
+        """{"type":"content_block_stop","index":0}""",
+        JSON3.read("""{"type":"content_block_stop","index":0}""")
+    )
+    @test isnothing(extract_content(AnthropicStream(), chunk_block_stop))
+
+    # Test case 5: text_delta extraction from content_block_delta
+    chunk_text_delta = StreamChunk(
         :content_block_delta,
-        """{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello world"}}""",
-        JSON3.read("""{"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello world"}}""")
+        """{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hello world"}}""",
+        JSON3.read("""{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hello world"}}""")
     )
-    @test extract_content(AnthropicStream(), chunk_text) == "Hello world"
+    @test extract_content(AnthropicStream(), chunk_text_delta) == "Hello world"
 
-    # Test case 4: thinking_delta extraction with include_thinking=true (default)
-    chunk_thinking = StreamChunk(
+    # Test case 6: thinking_delta extraction with include_thinking=true (default)
+    chunk_thinking_delta = StreamChunk(
         :content_block_delta,
-        """{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"This is a thought"}}""",
-        JSON3.read("""{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"This is a thought"}}""")
+        """{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"This is a thought"}}""",
+        JSON3.read("""{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"This is a thought"}}""")
     )
-    @test extract_content(AnthropicStream(), chunk_thinking) == "This is a thought"
+    @test extract_content(AnthropicStream(), chunk_thinking_delta) == "This is a thought"
 
-    # Test case 5: thinking_delta with include_thinking=false should return nothing
+    # Test case 7: thinking_delta with include_thinking=false should return nothing
     @test isnothing(extract_content(
-        AnthropicStream(), chunk_thinking, include_thinking = false))
+        AnthropicStream(), chunk_thinking_delta, include_thinking = false))
 
-    # Test case 6: Content block delta with unexpected delta type
-    chunk_unknown = StreamChunk(
+    # Test case 8: signature_delta should return nothing
+    chunk_signature_delta = StreamChunk(
         :content_block_delta,
-        """{"type":"content_block_delta","delta":{"type":"unknown_delta","content":"Something"}}""",
-        JSON3.read("""{"type":"content_block_delta","delta":{"type":"unknown_delta","content":"Something"}}""")
+        """{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"EqQBCgIYAhIM1gbcDa..."}}""",
+        JSON3.read("""{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"EqQBCgIYAhIM1gbcDa..."}}""")
     )
-    @test isnothing(extract_content(AnthropicStream(), chunk_unknown))
+    @test isnothing(extract_content(AnthropicStream(), chunk_signature_delta))
 
-    # Test case 7: Missing text field in text_delta should return nothing
+    # Test case 9: message_delta should return nothing
+    chunk_message_delta = StreamChunk(
+        :message_delta,
+        """{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null}}""",
+        JSON3.read("""{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null}}""")
+    )
+    @test isnothing(extract_content(AnthropicStream(), chunk_message_delta))
+
+    # Test case 10: message_stop should return nothing
+    chunk_message_stop = StreamChunk(
+        :message_stop,
+        """{"type":"message_stop"}""",
+        JSON3.read("""{"type":"message_stop"}""")
+    )
+    @test isnothing(extract_content(AnthropicStream(), chunk_message_stop))
+
+    # Test case 11: Empty text in text_delta should return empty string
+    chunk_empty_text = StreamChunk(
+        :content_block_delta,
+        """{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":""}}""",
+        JSON3.read("""{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":""}}""")
+    )
+    @test extract_content(AnthropicStream(), chunk_empty_text) == ""
+
+    # Test case 12: Missing text field in text_delta should return nothing
     chunk_missing_text = StreamChunk(
         :content_block_delta,
-        """{"type":"content_block_delta","delta":{"type":"text_delta"}}""",
-        JSON3.read("""{"type":"content_block_delta","delta":{"type":"text_delta"}}""")
+        """{"type":"content_block_delta","index":1,"delta":{"type":"text_delta"}}""",
+        JSON3.read("""{"type":"content_block_delta","index":1,"delta":{"type":"text_delta"}}""")
     )
     @test isnothing(extract_content(AnthropicStream(), chunk_missing_text))
 
-    # Test case 8: Missing thinking field in thinking_delta should return nothing
+    # Test case 13: Missing thinking field in thinking_delta should return nothing
     chunk_missing_thinking = StreamChunk(
         :content_block_delta,
-        """{"type":"content_block_delta","delta":{"type":"thinking_delta"}}""",
-        JSON3.read("""{"type":"content_block_delta","delta":{"type":"thinking_delta"}}""")
+        """{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta"}}""",
+        JSON3.read("""{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta"}}""")
     )
     @test isnothing(extract_content(AnthropicStream(), chunk_missing_thinking))
+
+    # Test case 14: content_block_start with text should extract the text
+    chunk_block_start_text = StreamChunk(
+        :content_block_start,
+        """{"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Initial text"}}""",
+        JSON3.read("""{"type":"content_block_start","index":0,"content_block":{"type":"text","text":"Initial text"}}""")
+    )
+    @test extract_content(AnthropicStream(), chunk_block_start_text) == "Initial text"
+
+    # Test case 15: content_block_start with thinking should extract the thinking
+    chunk_block_start_thinking = StreamChunk(
+        :content_block_start,
+        """{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"Initial thinking"}}""",
+        JSON3.read("""{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"Initial thinking"}}""")
+    )
+    @test extract_content(AnthropicStream(), chunk_block_start_thinking) ==
+          "Initial thinking"
+
+    # Test case 16: content_block_start with thinking but include_thinking=false should return nothing
+    @test isnothing(extract_content(
+        AnthropicStream(), chunk_block_start_thinking, include_thinking = false))
+
+    # Test case 17: content_block_stop with text should extract the text
+    chunk_block_stop_text = StreamChunk(
+        :content_block_stop,
+        """{"type":"content_block_stop","index":0,"content_block":{"type":"text","text":"Final text"}}""",
+        JSON3.read("""{"type":"content_block_stop","index":0,"content_block":{"type":"text","text":"Final text"}}""")
+    )
+    @test extract_content(AnthropicStream(), chunk_block_stop_text) == "Final text"
+
+    # Test case 18: content_block_stop with thinking should extract the thinking
+    chunk_block_stop_thinking = StreamChunk(
+        :content_block_stop,
+        """{"type":"content_block_stop","index":0,"content_block":{"type":"thinking","thinking":"Final thinking"}}""",
+        JSON3.read("""{"type":"content_block_stop","index":0,"content_block":{"type":"thinking","thinking":"Final thinking"}}""")
+    )
+    @test extract_content(AnthropicStream(), chunk_block_stop_thinking) == "Final thinking"
+
+    # Test case 19: content_block_stop with thinking but include_thinking=false should return nothing
+    @test isnothing(extract_content(
+        AnthropicStream(), chunk_block_stop_thinking, include_thinking = false))
 end

--- a/test/stream_openai.jl
+++ b/test/stream_openai.jl
@@ -63,63 +63,6 @@
     non_json_chunk = StreamChunk(data = "Plain text")
     @test isnothing(extract_content(openai_flavor, non_json_chunk))
 
-    # Test AnthropicStream
-    anthropic_flavor = AnthropicStream()
-
-    # Test with valid content block
-    valid_anthropic_chunk = StreamChunk(
-        json = JSON3.read("""
-        {
-            "content_block": {
-                "text": "Hello from Anthropic!"
-            }
-        }
-        """)
-    )
-    @test extract_content(anthropic_flavor, valid_anthropic_chunk) ==
-          "Hello from Anthropic!"
-
-    # Test with valid delta
-    valid_delta_chunk = StreamChunk(
-        json = JSON3.read("""
-        {
-            "delta": {
-                "text": "Delta text"
-            }
-        }
-        """)
-    )
-    @test extract_content(anthropic_flavor, valid_delta_chunk) == "Delta text"
-
-    # Test with missing text in content block
-    missing_text_chunk = StreamChunk(
-        json = JSON3.read("""
-        {
-            "content_block": {
-                "type": "text"
-            }
-        }
-        """)
-    )
-    @test isnothing(extract_content(anthropic_flavor, missing_text_chunk))
-
-    # Test with non-zero index (should return nothing)
-    non_zero_index_chunk = StreamChunk(
-        json = JSON3.read("""
-        {
-            "index": 1,
-            "content_block": {
-                "text": "This should be ignored"
-            }
-        }
-        """)
-    )
-    @test isnothing(extract_content(anthropic_flavor, non_zero_index_chunk))
-
-    # Test with non-JSON chunk for Anthropic
-    non_json_anthropic_chunk = StreamChunk(data = "Plain Anthropic text")
-    @test isnothing(extract_content(anthropic_flavor, non_json_anthropic_chunk))
-
     # Test with unsupported flavor
     struct UnsupportedFlavor <: AbstractStreamFlavor end
     unsupported_flavor = UnsupportedFlavor()
@@ -175,55 +118,6 @@ end
         JSON3.read("""{"choices":[{"delta":{"content":"First"}},{"delta":{"content":"Second"}}]}""")
     )
     @test extract_content(OpenAIStream(), multiple_choices_chunk) == "First"
-
-    ### AnthropicStream
-    # Test case 1: Valid JSON with content in content_block
-    valid_chunk = StreamChunk(
-        nothing,
-        """{"index":0,"content_block":{"text":"Hello from Anthropic"}}""",
-        JSON3.read("""{"index":0,"content_block":{"text":"Hello from Anthropic"}}""")
-    )
-    @test extract_content(AnthropicStream(), valid_chunk) == "Hello from Anthropic"
-
-    # Test case 2: Valid JSON with content in delta
-    delta_chunk = StreamChunk(
-        nothing,
-        """{"index":0,"delta":{"text":"Delta content"}}""",
-        JSON3.read("""{"index":0,"delta":{"text":"Delta content"}}""")
-    )
-    @test extract_content(AnthropicStream(), delta_chunk) == "Delta content"
-
-    # Test case 3: Valid JSON without text in content_block
-    no_text_chunk = StreamChunk(
-        nothing,
-        """{"index":0,"content_block":{"type":"text"}}""",
-        JSON3.read("""{"index":0,"content_block":{"type":"text"}}""")
-    )
-    @test isnothing(extract_content(AnthropicStream(), no_text_chunk))
-
-    # Test case 4: Valid JSON with non-zero index
-    non_zero_index_chunk = StreamChunk(
-        nothing,
-        """{"index":1,"content_block":{"text":"Should be ignored"}}""",
-        JSON3.read("""{"index":1,"content_block":{"text":"Should be ignored"}}""")
-    )
-    @test isnothing(extract_content(AnthropicStream(), non_zero_index_chunk))
-
-    # Test case 5: Chunk with non-JSON data
-    non_json_chunk = StreamChunk(
-        nothing,
-        "This is not JSON",
-        nothing
-    )
-    @test isnothing(extract_content(AnthropicStream(), non_json_chunk))
-
-    # Test case 6: Valid JSON with empty content
-    empty_content_chunk = StreamChunk(
-        nothing,
-        """{"index":0,"content_block":{"text":""}}""",
-        JSON3.read("""{"index":0,"content_block":{"text":""}}""")
-    )
-    @test extract_content(AnthropicStream(), empty_content_chunk) == ""
 
     # Test case 7: Unknown flavor
     struct UnknownFlavor <: AbstractStreamFlavor end


### PR DESCRIPTION
This PR adds support for Anthropic's text_delta format in content extraction. The new format is used in recent Claude API responses and needs to be handled specifically to extract text content correctly.